### PR TITLE
0.0.7 java.fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "async": ">= 0.2.9",
-    "java": ">= 0.2.3"
+    "java": "~ 0"
   },
   "readmeFilename": "README.md",
   "description": "A node.js wrapper for Boilerpipe, an excellent Java library for boilerplate removal and fulltext extraction from HTML pages.",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "build": "coffee -co lib/ src/",
     "prepublish": "coffee -co lib/ src/",
     "postpublish": "rm -rf lib",
-    "test": "mocha --compilers coffee:coffee-script --globals lw --recursive ./test -t 10000"
+    "test": "mocha --compilers coffee:coffee-script/register --globals lw --recursive ./test -t 10000"
   }
 }

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,6 +1,8 @@
 async = require 'async'
 java = require 'java'
 
+java.options.push("-Xss1280k")
+
 java.classpath.push "#{__dirname}/../jar/nekohtml-1.9.13.jar"
 java.classpath.push "#{__dirname}/../jar/xerces-2.9.1.jar"
 java.classpath.push "#{__dirname}/../jar/boilerpipe-core-1.2.0-xissy.jar"


### PR DESCRIPTION
This is a fix to get JAVA and YARN to work with boilerpipe.

With the latest kernel for Debian 9 and some security fixes its now required to use Xss1280k as options (joeferner/node-java/issues/399) 

With YARN the joeferner/node-java repository has wrong versions in some older releases that start with 5 and do not work any more. By forcing the 0 major it fall back to the latest and correct version of 0.8.0.
